### PR TITLE
Meta keys clean header

### DIFF
--- a/tap_sftp/discover.py
+++ b/tap_sftp/discover.py
@@ -17,7 +17,7 @@ def discover_streams(config):
         LOGGER.info('Sampling records to determine table JSON schema "%s".', table_spec['table_name'])
         schema = json_schema.get_schema_for_table(conn, table_spec, config)
         stream_md = metadata.get_standard_metadata(schema,
-                                                   key_properties=table_spec.get('key_properties'),
+                                                   key_properties=table_spec.get('key_properties', ['_sdc_source_file', '_sdc_source_lineno']),
                                                    replication_method='INCREMENTAL')
         streams.append(
             {

--- a/tap_sftp/singer_encodings/csv_handler.py
+++ b/tap_sftp/singer_encodings/csv_handler.py
@@ -42,8 +42,8 @@ def get_row_iterator(iterable, options=None):
     if 'sanitize_headers' in options and options['sanitize_headers']:
         reader.fieldnames = [sanitize_colname(col) for col in reader.fieldnames].copy()
 
-    headers = set(reader.fieldnames + ['_sdc_source_file', '_sdc_source_lineno'])
-    # headers = set(reader.fieldnames)
+    # headers = set(reader.fieldnames + ['_sdc_source_file', '_sdc_source_lineno'])
+    headers = set(reader.fieldnames)
     if options.get('key_properties'):
         key_properties = set(options['key_properties'])
         if not key_properties.issubset(headers):

--- a/tap_sftp/singer_encodings/csv_handler.py
+++ b/tap_sftp/singer_encodings/csv_handler.py
@@ -34,7 +34,7 @@ def get_row_iterator(iterable, options=None):
     # Replace any NULL bytes in the line given to the DictReader
     reader = csv.DictReader(
         io.TextIOWrapper(iterable, encoding=options.get('encoding', 'utf-8')),
-        fieldnames=None,
+        #fieldnames=None,
         restkey=SDC_EXTRA_COLUMN,
         delimiter=options.get('delimiter', ',')
     )

--- a/tap_sftp/singer_encodings/csv_handler.py
+++ b/tap_sftp/singer_encodings/csv_handler.py
@@ -42,8 +42,8 @@ def get_row_iterator(iterable, options=None):
     if 'sanitize_headers' in options and options['sanitize_headers']:
         reader.fieldnames = [sanitize_colname(col) for col in reader.fieldnames].copy()
 
-    # headers = set(reader.fieldnames + ['_sdc_source_file', '_sdc_source_lineno'])
-    headers = set(reader.fieldnames)
+    headers = set(reader.fieldnames + ['_sdc_source_file', '_sdc_source_lineno'])
+    # headers = set(reader.fieldnames)
     if options.get('key_properties'):
         key_properties = set(options['key_properties'])
         if not key_properties.issubset(headers):

--- a/tap_sftp/singer_encodings/csv_handler.py
+++ b/tap_sftp/singer_encodings/csv_handler.py
@@ -2,6 +2,8 @@ import codecs
 import csv
 import io
 import os
+import singer
+import re
 
 from tap_sftp import decrypt
 from tap_sftp.singer_encodings import compression
@@ -18,6 +20,12 @@ def get_row_iterators(iterable, options={}, infer_compression=False):
         yield get_row_iterator(item, options=options)
 
 
+def sanitize_colname(col_name):
+    sanitized = re.sub(r'[^0-9a-zA-Z_]+', '_', col_name)
+    prefixed = re.sub(r'^(\d+)', r'x_\1', sanitized)
+    return prefixed.lower()
+
+
 def get_row_iterator(iterable, options=None):
     """Accepts an interable, options and returns a csv.DictReader object
     which can be used to yield CSV rows."""
@@ -31,7 +39,11 @@ def get_row_iterator(iterable, options=None):
         delimiter=options.get('delimiter', ',')
     )
 
+    if 'sanitize_headers' in options and options['sanitize_headers']:
+        reader.fieldnames = [sanitize_colname(col) for col in reader.fieldnames]
+
     headers = set(reader.fieldnames)
+
     if options.get('key_properties'):
         key_properties = set(options['key_properties'])
         if not key_properties.issubset(headers):

--- a/tap_sftp/singer_encodings/csv_handler.py
+++ b/tap_sftp/singer_encodings/csv_handler.py
@@ -39,7 +39,7 @@ def get_row_iterator(iterable, options=None):
         delimiter=options.get('delimiter', ',')
     )
 
-    if 'sanitize_headers' in options and options['sanitize_headers']:
+    if 'clean_colnames' in options and options['clean_colnames']:
         reader.fieldnames = [sanitize_colname(col) for col in reader.fieldnames].copy()
 
     headers = set(reader.fieldnames + ['_sdc_source_file', '_sdc_source_lineno'])

--- a/tap_sftp/singer_encodings/csv_handler.py
+++ b/tap_sftp/singer_encodings/csv_handler.py
@@ -34,7 +34,7 @@ def get_row_iterator(iterable, options=None):
     # Replace any NULL bytes in the line given to the DictReader
     reader = csv.DictReader(
         io.TextIOWrapper(iterable, encoding=options.get('encoding', 'utf-8')),
-        #fieldnames=None,
+        fieldnames=None,
         restkey=SDC_EXTRA_COLUMN,
         delimiter=options.get('delimiter', ',')
     )
@@ -43,7 +43,7 @@ def get_row_iterator(iterable, options=None):
         reader.fieldnames = [sanitize_colname(col) for col in reader.fieldnames].copy()
 
     headers = set(reader.fieldnames + ['_sdc_source_file', '_sdc_source_lineno'])
-    # headers = set(reader.fieldnames)
+
     if options.get('key_properties'):
         key_properties = set(options['key_properties'])
         if not key_properties.issubset(headers):

--- a/tap_sftp/singer_encodings/csv_handler.py
+++ b/tap_sftp/singer_encodings/csv_handler.py
@@ -42,8 +42,8 @@ def get_row_iterator(iterable, options=None):
     if 'sanitize_headers' in options and options['sanitize_headers']:
         reader.fieldnames = [sanitize_colname(col) for col in reader.fieldnames].copy()
 
-    headers = set(reader.fieldnames)
-
+    headers = set(reader.fieldnames + ['_sdc_source_file', '_sdc_source_lineno'])
+    # headers = set(reader.fieldnames)
     if options.get('key_properties'):
         key_properties = set(options['key_properties'])
         if not key_properties.issubset(headers):

--- a/tap_sftp/singer_encodings/csv_handler.py
+++ b/tap_sftp/singer_encodings/csv_handler.py
@@ -40,7 +40,7 @@ def get_row_iterator(iterable, options=None):
     )
 
     if 'sanitize_headers' in options and options['sanitize_headers']:
-        reader.fieldnames = [sanitize_colname(col) for col in reader.fieldnames]
+        reader.fieldnames = [sanitize_colname(col) for col in reader.fieldnames].copy()
 
     headers = set(reader.fieldnames)
 

--- a/tap_sftp/singer_encodings/json_schema.py
+++ b/tap_sftp/singer_encodings/json_schema.py
@@ -42,7 +42,7 @@ def sample_file(conn, table_spec, f, sample_rate, max_records, config):
             'delimiter': table_spec['delimiter'],
             'file_name': f['filepath'],
             'encoding': table_spec.get('encoding', 'utf-8'),
-            'sanitize_headers': table_spec.get('sanitize_headers', False)}
+            'clean_colnames': table_spec.get('clean_colnames', False)}
 
     readers = csv_handler.get_row_iterators(file_handle, options=opts, infer_compression=True)
 

--- a/tap_sftp/singer_encodings/json_schema.py
+++ b/tap_sftp/singer_encodings/json_schema.py
@@ -41,7 +41,8 @@ def sample_file(conn, table_spec, f, sample_rate, max_records, config):
     opts = {'key_properties': table_spec['key_properties'],
             'delimiter': table_spec['delimiter'],
             'file_name': f['filepath'],
-            'encoding': table_spec.get('encoding', 'utf-8')}
+            'encoding': table_spec.get('encoding', 'utf-8'),
+            'sanitize_headers': table_spec.get('sanitize_headers', False)}
 
     readers = csv_handler.get_row_iterators(file_handle, options=opts, infer_compression=True)
 

--- a/tap_sftp/singer_encodings/json_schema.py
+++ b/tap_sftp/singer_encodings/json_schema.py
@@ -38,7 +38,7 @@ def sample_file(conn, table_spec, f, sample_rate, max_records, config):
         file_handle = conn.get_file_handle(f)
 
     # Add file_name to opts and flag infer_compression to support gzipped files
-    opts = {'key_properties': table_spec['key_properties'],
+    opts = {'key_properties': table_spec.get('key_properties', ['_sdc_source_file', '_sdc_source_lineno']),
             'delimiter': table_spec['delimiter'],
             'file_name': f['filepath'],
             'encoding': table_spec.get('encoding', 'utf-8'),

--- a/tap_sftp/sync.py
+++ b/tap_sftp/sync.py
@@ -60,7 +60,7 @@ def sync_file(sftp_file_spec, stream, table_spec, config, sftp_client):
         file_handle = sftp_client.get_file_handle(sftp_file_spec)
 
     # Add file_name to opts and flag infer_compression to support gzipped files
-    opts = {'key_properties': table_spec['key_properties'],
+    opts = {'key_properties': table_spec.get('key_properties', ['_sdc_source_file', '_sdc_source_lineno']),
             'delimiter': table_spec.get('delimiter', ','),
             'file_name': sftp_file_spec['filepath'],
             'encoding': table_spec.get('encoding', 'utf-8'),

--- a/tap_sftp/sync.py
+++ b/tap_sftp/sync.py
@@ -63,7 +63,8 @@ def sync_file(sftp_file_spec, stream, table_spec, config, sftp_client):
     opts = {'key_properties': table_spec['key_properties'],
             'delimiter': table_spec.get('delimiter', ','),
             'file_name': sftp_file_spec['filepath'],
-            'encoding': table_spec.get('encoding', 'utf-8')}
+            'encoding': table_spec.get('encoding', 'utf-8'),
+            'sanitize_headers': table_spec.get('sanitize_headers', False)}
 
     readers = csv_handler.get_row_iterators(file_handle, options=opts, infer_compression=True)
 

--- a/tap_sftp/sync.py
+++ b/tap_sftp/sync.py
@@ -60,7 +60,7 @@ def sync_file(sftp_file_spec, stream, table_spec, config, sftp_client):
         file_handle = sftp_client.get_file_handle(sftp_file_spec)
 
     # Add file_name to opts and flag infer_compression to support gzipped files
-    opts = {'key_properties': table_spec.get('key_properties', ['_sdc_source_file', '_sdc_source_lineno']),
+    opts = {'key_properties': table_spec.get('key_properties'),
             'delimiter': table_spec.get('delimiter', ','),
             'file_name': sftp_file_spec['filepath'],
             'encoding': table_spec.get('encoding', 'utf-8'),

--- a/tap_sftp/tap.py
+++ b/tap_sftp/tap.py
@@ -12,8 +12,7 @@ from tap_sftp.sync import sync_stream
 
 REQUIRED_CONFIG_KEYS = ["username", "port", "host", "tables", "start_date"]
 REQUIRED_DECRYPT_CONFIG_KEYS = ['SSM_key_name', 'gnupghome', 'passphrase']
-# REQUIRED_TABLE_SPEC_CONFIG_KEYS = ["key_properties", "delimiter", "table_name", "search_prefix", "search_pattern"]
-REQUIRED_TABLE_SPEC_CONFIG_KEYS = ["delimiter", "table_name", "search_prefix", "search_pattern"]
+REQUIRED_TABLE_SPEC_CONFIG_KEYS = ["key_properties", "delimiter", "table_name", "search_prefix", "search_pattern"]
 LOGGER = singer.get_logger()
 
 

--- a/tap_sftp/tap.py
+++ b/tap_sftp/tap.py
@@ -12,8 +12,8 @@ from tap_sftp.sync import sync_stream
 
 REQUIRED_CONFIG_KEYS = ["username", "port", "host", "tables", "start_date"]
 REQUIRED_DECRYPT_CONFIG_KEYS = ['SSM_key_name', 'gnupghome', 'passphrase']
-REQUIRED_TABLE_SPEC_CONFIG_KEYS = ["key_properties", "delimiter", "table_name", "search_prefix", "search_pattern"]
-
+# REQUIRED_TABLE_SPEC_CONFIG_KEYS = ["key_properties", "delimiter", "table_name", "search_prefix", "search_pattern"]
+REQUIRED_TABLE_SPEC_CONFIG_KEYS = ["delimiter", "table_name", "search_prefix", "search_pattern"]
 LOGGER = singer.get_logger()
 
 

--- a/tests/configuration/unsanitized_file.csv
+++ b/tests/configuration/unsanitized_file.csv
@@ -1,0 +1,2 @@
+id,Col($2)
+data1,data2

--- a/tests/tox_tests/test_med_00_parse_csv.py
+++ b/tests/tox_tests/test_med_00_parse_csv.py
@@ -6,7 +6,7 @@ def test_sanitize_headers():
     options = {
         'delimiter': ',',
         'key_properties': ['id'],
-        'sanitize_headers': True,
+        'clean_colnames': True,
     }
 
     with open(get_sample_file_path('unsanitized_file.csv'), 'rb') as file:

--- a/tests/tox_tests/test_med_00_parse_csv.py
+++ b/tests/tox_tests/test_med_00_parse_csv.py
@@ -1,0 +1,32 @@
+from tap_sftp.singer_encodings import csv_handler
+from tests.configuration.fixtures import get_sample_file_path
+
+def test_sanitize_headers():
+    """Test the parser."""
+    options = {
+        'delimiter': ',',
+        'key_properties': ['id'],
+        'sanitize_headers': True,
+    }
+
+    with open(get_sample_file_path('unsanitized_file.csv'), 'rb') as file:
+        parser = csv_handler.get_row_iterator(file, options=options)
+
+
+
+    assert parser.fieldnames == ['id', 'col_2_']
+
+
+def test_no_sanitized_headers():
+    """Test the parser."""
+    options = {
+        'delimiter': ',',
+        'key_properties': ['id'],
+        'sanitize_headers': False,
+    }
+
+    with open(get_sample_file_path('unsanitized_file.csv'), 'rb') as file:
+
+        parser = csv_handler.get_row_iterator(file, options=options)
+        
+    assert parser.fieldnames == ['id', 'Col($2)']


### PR DESCRIPTION
Adding:

a crude option to clean special characters from headers
The possibility to reference metadata columns (_sdc_source_file, _sdc_source_lineno) in the key_properties config
These are fairly pragmatic changes, relating to our immediate requirements. While I believe these are generic features that are useful for others, the long-term solution to these issues might look different.