### PR TITLE
Keystring

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,4 @@ coverage.xml
 
 # Misc
 ._*
+catalog.json

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 singer-python==5.9.0
-paramiko==2.6.0
+paramiko==3.0.0
 backoff==1.8.0
 terminaltables==3.1.0
 python-gnupg==0.4.6

--- a/tap_sftp/client.py
+++ b/tap_sftp/client.py
@@ -31,9 +31,11 @@ class SFTPConnection():
         self.decrypted_file = None
         self.key = None
         self.transport = None
+        self.private_key_string = private_key_string
 
         if private_key_string:
-            self.key = paramiko.RSAKey.from_private_key(io.StringIO(private_key_string))
+            key_io = io.StringIO(self.private_key_string)
+            self.key = paramiko.RSAKey.from_private_key(key_io)
 
         if private_key_file:
             key_path = os.path.expanduser(private_key_file)

--- a/tap_sftp/client.py
+++ b/tap_sftp/client.py
@@ -39,7 +39,9 @@ class SFTPConnection():
 
             with open('private_key.pem', 'w') as f:
                 f.write(private_key_string)
-                self.key = paramiko.RSAKey.from_private_key_file('private_key.pem')
+                f.flush()
+                
+            self.key = paramiko.RSAKey.from_private_key_file('private_key.pem')
 
             # key_io = io.StringIO(self.private_key_string)
             # self.key = paramiko.RSAKey.from_private_key(key_io)

--- a/tap_sftp/client.py
+++ b/tap_sftp/client.py
@@ -209,5 +209,6 @@ def connection(config):
                           password=config.get('password'),
                           private_key_file=config.get('private_key_file'),
                           port=config.get('port'),
-                          private_key_string = config.get('private_key_string')
+                          private_key_string = config.get('private_key_string'),
+                          disable_sha2 = config.get('disable_sha2'),
     )

--- a/tap_sftp/client.py
+++ b/tap_sftp/client.py
@@ -76,8 +76,11 @@ class SFTPConnection():
                                                     "pubkeys": ["rsa-sha2-256", "rsa-sha2-512"]
                                                 })
         else:
-            self.transport = paramiko.Transport((self.host, self.port))
-        
+            self.transport = paramiko.Transport((self.host, self.port),
+                                    disabled_algorithms={
+                                        "pubkeys": ["rsa-sha2-256", "rsa-sha2-512"]
+                                    })
+
         self.transport.default_window_size = paramiko.common.MAX_WINDOW_SIZE
         self.transport.packetizer.REKEY_BYTES = pow(2, 40)  # 1TB max, this is a security degradation!
         self.transport.packetizer.REKEY_PACKETS = pow(2, 40)  # 1TB max, this is a security degradation!

--- a/tap_sftp/client.py
+++ b/tap_sftp/client.py
@@ -218,6 +218,6 @@ def connection(config):
                           private_key_file=config.get('private_key_file'),
                           port=config.get('port'),
                           private_key_string = config.get('private_key_string'),
-                          disable_sha2 = config.get('disable_sha2'),
-                          avoid_key_rotation = config.get('avoid_key_rotation')
+                          disable_sha2 = config.get('disable_sha2', False),
+                          avoid_key_rotation = config.get('avoid_key_rotation', False)
     )

--- a/tap_sftp/client.py
+++ b/tap_sftp/client.py
@@ -46,9 +46,9 @@ class SFTPConnection():
             key_io = io.StringIO(self.private_key_string)
             self.key = paramiko.RSAKey.from_private_key(key_io)
 
-        if private_key_file:
-            key_path = os.path.expanduser(private_key_file)
-            self.key = paramiko.RSAKey.from_private_key_file(key_path)
+        # if private_key_file:
+        #     key_path = os.path.expanduser(private_key_file)
+        #     self.key = paramiko.RSAKey.from_private_key_file(key_path)
 
         self.__connect()
 
@@ -64,21 +64,24 @@ class SFTPConnection():
     def __connect(self):
 
         LOGGER.info('Creating new connection to SFTP...')
-
-        if self.disable_sha2:
-            self.transport = paramiko.Transport((self.host, self.port),
-                                                disabled_algorithms={
-                                                    "pubkeys": ["rsa-sha2-256", "rsa-sha2-512"]
-                                                })
-        else:
-            self.transport = paramiko.Transport((self.host, self.port))
+        self.transport = paramiko.Transport((self.host, self.port),
+                                            disabled_algorithms={
+                                                "pubkeys": ["rsa-sha2-256", "rsa-sha2-512"]
+                                            })
+        # if self.disable_sha2:
+        #     self.transport = paramiko.Transport((self.host, self.port),
+        #                                         disabled_algorithms={
+        #                                             "pubkeys": ["rsa-sha2-256", "rsa-sha2-512"]
+        #                                         })
+        # else:
+        #     self.transport = paramiko.Transport((self.host, self.port))
         
         self.transport.default_window_size = paramiko.common.MAX_WINDOW_SIZE
         self.transport.packetizer.REKEY_BYTES = pow(2, 40)  # 1TB max, this is a security degradation!
         self.transport.packetizer.REKEY_PACKETS = pow(2, 40)  # 1TB max, this is a security degradation!
 
         self.transport.use_compression(True)
-        self.transport.connect(username=self.username, password=self.password, hostkey=None, pkey=self.key)
+        self.transport.connect(username=self.username, password=None, hostkey=None, pkey=self.key)
         self.__sftp = paramiko.SFTPClient.from_transport(self.transport)
         LOGGER.info('Connection successful')
 

--- a/tap_sftp/client.py
+++ b/tap_sftp/client.py
@@ -34,15 +34,6 @@ class SFTPConnection():
         self.private_key_string = private_key_string
 
         if private_key_string:
-            LOGGER.info(f'Using private key string {private_key_string}')
-            LOGGER.info(f"The private key string is of type {type(private_key_string)}")
-
-            # with open('private_key.pem', 'w') as f:
-            #     f.write(private_key_string)
-            #     f.flush()
-
-            # self.key = paramiko.RSAKey.from_private_key_file('private_key.pem')
-
             key_io = io.StringIO(self.private_key_string)
             self.key = paramiko.RSAKey.from_private_key(key_io)
 

--- a/tap_sftp/client.py
+++ b/tap_sftp/client.py
@@ -76,11 +76,8 @@ class SFTPConnection():
                                                     "pubkeys": ["rsa-sha2-256", "rsa-sha2-512"]
                                                 })
         else:
-            self.transport = paramiko.Transport((self.host, self.port),
-                                    disabled_algorithms={
-                                        "pubkeys": ["rsa-sha2-256", "rsa-sha2-512"]
-                                    })
-
+            self.transport = paramiko.Transport((self.host, self.port))
+        
         self.transport.default_window_size = paramiko.common.MAX_WINDOW_SIZE
         self.transport.packetizer.REKEY_BYTES = pow(2, 40)  # 1TB max, this is a security degradation!
         self.transport.packetizer.REKEY_PACKETS = pow(2, 40)  # 1TB max, this is a security degradation!

--- a/tap_sftp/client.py
+++ b/tap_sftp/client.py
@@ -37,14 +37,14 @@ class SFTPConnection():
             LOGGER.info(f'Using private key string {private_key_string}')
             LOGGER.info(f"The private key string is of type {type(private_key_string)}")
 
-            with open('private_key.pem', 'w') as f:
-                f.write(private_key_string)
-                f.flush()
-                
-            self.key = paramiko.RSAKey.from_private_key_file('private_key.pem')
+            # with open('private_key.pem', 'w') as f:
+            #     f.write(private_key_string)
+            #     f.flush()
 
-            # key_io = io.StringIO(self.private_key_string)
-            # self.key = paramiko.RSAKey.from_private_key(key_io)
+            # self.key = paramiko.RSAKey.from_private_key_file('private_key.pem')
+
+            key_io = io.StringIO(self.private_key_string)
+            self.key = paramiko.RSAKey.from_private_key(key_io)
 
         if private_key_file:
             key_path = os.path.expanduser(private_key_file)

--- a/tap_sftp/client.py
+++ b/tap_sftp/client.py
@@ -35,7 +35,8 @@ class SFTPConnection():
 
         if private_key_string:
             LOGGER.info(f'Using private key string {private_key_string}')
-            
+            LOGGER.info(f"The private key string is of type {type(private_key_string)}")
+
             key_io = io.StringIO(self.private_key_string)
             self.key = paramiko.RSAKey.from_private_key(key_io)
 

--- a/tap_sftp/client.py
+++ b/tap_sftp/client.py
@@ -45,11 +45,13 @@ class SFTPConnection():
         if private_key_string:
             key_io = io.StringIO(self.private_key_string)
             self.key = paramiko.RSAKey.from_private_key(key_io)
-
-        # if private_key_file:
-        #     key_path = os.path.expanduser(private_key_file)
-        #     self.key = paramiko.RSAKey.from_private_key_file(key_path)
-
+            self.password = None
+        elif private_key_file:
+            key_path = os.path.expanduser(private_key_file)
+            self.key = paramiko.RSAKey.from_private_key_file(key_path)
+            self.password = None
+        else:
+            self.key = None
         self.__connect()
 
     # If connection is snapped during connect flow, retry up to a
@@ -64,17 +66,17 @@ class SFTPConnection():
     def __connect(self):
 
         LOGGER.info('Creating new connection to SFTP...')
-        self.transport = paramiko.Transport((self.host, self.port),
-                                            disabled_algorithms={
-                                                "pubkeys": ["rsa-sha2-256", "rsa-sha2-512"]
-                                            })
-        # if self.disable_sha2:
-        #     self.transport = paramiko.Transport((self.host, self.port),
-        #                                         disabled_algorithms={
-        #                                             "pubkeys": ["rsa-sha2-256", "rsa-sha2-512"]
-        #                                         })
-        # else:
-        #     self.transport = paramiko.Transport((self.host, self.port))
+        # self.transport = paramiko.Transport((self.host, self.port),
+        #                                     disabled_algorithms={
+        #                                         "pubkeys": ["rsa-sha2-256", "rsa-sha2-512"]
+        #                                     })
+        if self.disable_sha2:
+            self.transport = paramiko.Transport((self.host, self.port),
+                                                disabled_algorithms={
+                                                    "pubkeys": ["rsa-sha2-256", "rsa-sha2-512"]
+                                                })
+        else:
+            self.transport = paramiko.Transport((self.host, self.port))
         
         self.transport.default_window_size = paramiko.common.MAX_WINDOW_SIZE
         self.transport.packetizer.REKEY_BYTES = pow(2, 40)  # 1TB max, this is a security degradation!

--- a/tap_sftp/client.py
+++ b/tap_sftp/client.py
@@ -37,8 +37,12 @@ class SFTPConnection():
             LOGGER.info(f'Using private key string {private_key_string}')
             LOGGER.info(f"The private key string is of type {type(private_key_string)}")
 
-            key_io = io.StringIO(self.private_key_string)
-            self.key = paramiko.RSAKey.from_private_key(key_io)
+            with open('private_key.pem', 'w') as f:
+                f.write(private_key_string)
+                self.key = paramiko.RSAKey.from_private_key_file('private_key.pem')
+
+            # key_io = io.StringIO(self.private_key_string)
+            # self.key = paramiko.RSAKey.from_private_key(key_io)
 
         if private_key_file:
             key_path = os.path.expanduser(private_key_file)

--- a/tap_sftp/client.py
+++ b/tap_sftp/client.py
@@ -4,7 +4,7 @@ import stat
 import tempfile
 import time
 from datetime import datetime
-
+import io
 import backoff
 import paramiko
 import pytz
@@ -23,7 +23,7 @@ def handle_backoff(details):
 
 
 class SFTPConnection():
-    def __init__(self, host, username, password=None, private_key_file=None, port=None):
+    def __init__(self, host, username, password=None, private_key_file=None, port=None, private_key_string=None):
         self.host = host
         self.username = username
         self.password = password
@@ -31,6 +31,9 @@ class SFTPConnection():
         self.decrypted_file = None
         self.key = None
         self.transport = None
+
+        if private_key_string:
+            self.key = paramiko.RSAKey.from_private_key(io.StringIO(private_key_string))
 
         if private_key_file:
             key_path = os.path.expanduser(private_key_file)
@@ -187,4 +190,6 @@ def connection(config):
                           config['username'],
                           password=config.get('password'),
                           private_key_file=config.get('private_key_file'),
-                          port=config.get('port'))
+                          port=config.get('port'),
+                          private_key_string = config.get('private_key_string')
+    )

--- a/tap_sftp/client.py
+++ b/tap_sftp/client.py
@@ -34,6 +34,8 @@ class SFTPConnection():
         self.private_key_string = private_key_string
 
         if private_key_string:
+            LOGGER.info(f'Using private key string {private_key_string}')
+            
             key_io = io.StringIO(self.private_key_string)
             self.key = paramiko.RSAKey.from_private_key(key_io)
 

--- a/tap_sftp/discover.py
+++ b/tap_sftp/discover.py
@@ -16,6 +16,9 @@ def discover_streams(config):
     for table_spec in tables:
         LOGGER.info('Sampling records to determine table JSON schema "%s".', table_spec['table_name'])
         schema = json_schema.get_schema_for_table(conn, table_spec, config)
+
+        if not schema.get('properties'):
+            schema['properties'] = {}
         stream_md = metadata.get_standard_metadata(schema,
                                                    key_properties=table_spec.get('key_properties', ['_sdc_source_file', '_sdc_source_lineno']),  # noqa
                                                    replication_method='INCREMENTAL')

--- a/tap_sftp/sync.py
+++ b/tap_sftp/sync.py
@@ -11,7 +11,7 @@ LOGGER = singer.get_logger()
 def sync_stream(config, state, stream):
     table_name = stream.tap_stream_id
     modified_since = utils.strptime_to_utc(singer.get_bookmark(state, table_name, 'modified_since') or
-                                           config['start_date'])
+                                        config['start_date'])
 
     LOGGER.info('Syncing table "%s".', table_name)
     LOGGER.info('Getting files modified since %s.', modified_since)


### PR DESCRIPTION
Added new options and functionality:
- Option to disable SHA2 algorithms for old servers `disable_sha2`
- Option to give ssh-key as text string: `private_key_string`
- Option to reduce key rotation for encryption in transit: `avoid_key_rotation`

In addition, the tap now ensures that Schema messages always has a `properties` key, which wasn't the case if no files matching the search pattern were found on the server.